### PR TITLE
Segment important dates by faculty

### DIFF
--- a/src/app/chart/chart.component.html
+++ b/src/app/chart/chart.component.html
@@ -214,7 +214,7 @@ loadCourseData(inputCourse)
     <p>This site does not update in realtime and cannot tell you how quickly waitlists drop.
     </p>
     <ul>
-      <li>All dates and deadlines are based on the <strong>Faculty of Arts and Science, even if the course visible in the chart isn't offered by FAS.</strong> Double check if your Faculty's deadlines and policies are the same as FAS!!</li>
+      <li>Some dates and deadlines are based on the <strong>Faculty of Arts and Science, even if the course visible in the chart isn't offered by FAS.</strong> Double check your Faculty's deadlines and policies!!</li>
       <li>Course information is sourced from <a href="https://ttb.utoronto.ca/">here</a>.</li>
       <li>Timetable Prototype is an app I've made that works as an alternative to Timetable Builder: <a href="https://icprplshelp.github.io/UofT-Timetable-Prototype-V2/">HERE</a></li>
       <li>Symbol guides: 🌐 sync | 💤 async | 📶 hybrid</li>

--- a/src/app/chart/chart.component.ts
+++ b/src/app/chart/chart.component.ts
@@ -6,6 +6,7 @@ import {
   EnrollmentCapChange,
   EnrollmentCapComplex,
   ImportantTimestamps,
+  ImportantTimestampsByFaculty,
   IndividualSessionInfo,
   Instructor,
   Meeting,
@@ -47,6 +48,7 @@ export class ChartComponent implements OnInit {
 
   smallMessage =
     'Your screen is small. Lecture sections are compressed. M#### means the maximum enrollment for that section. Consider rotating your device.';
+  importantDatesByFaculty: ImportantTimestampsByFaculty | null = null;
   importantDates: ImportantTimestamps | null = null;
   sessionColl: SessionCollection | null = null;
   isSummer: boolean = false; // true if the course is offered in the summer
@@ -81,7 +83,7 @@ export class ChartComponent implements OnInit {
   }
 
   reloadImportantDatesAndValues(done: (() => void)): void {
-    let tempData: ImportantTimestamps;
+    let tempData: ImportantTimestampsByFaculty;
     this.crsgetter.getImportantDates().subscribe({
       next: (data) => {
         tempData = data;
@@ -90,7 +92,7 @@ export class ChartComponent implements OnInit {
         // console.log("Couldn't load important timestamps");
       },
       complete: () => {
-        this.importantDates = tempData;
+        this.importantDatesByFaculty = tempData;
         // const curSession = this.crsgetter.session;
         // const curSessionIndex = this.sessionColl?.sessions.map(s => s.sessionCode).indexOf(curSession) ?? -1;
         // this.sessionWasLastYear = 2 <= (curSessionIndex - (this.sessionColl?.sessions.length ?? 0));
@@ -423,7 +425,8 @@ export class ChartComponent implements OnInit {
       this.importantDates !== null &&
       this.importantDates !== undefined &&
       this.faculty !== 'APSC' &&
-      crsCodeNow[crsCodeNow.length - 2] === '1' &&
+      // StG and UTSC
+      ['1', '3'].includes(crsCodeNow[crsCodeNow.length - 2]) &&
       this.importantDates.first !== undefined &&
       this.importantDates.second !== undefined &&
       this.importantDates.third !== undefined &&
@@ -1376,6 +1379,10 @@ export class ChartComponent implements OnInit {
       return;
     }
     this.faculty = crs.faculty;
+    this.importantDates =
+      this.importantDatesByFaculty?.[this.faculty] ??
+      this.importantDatesByFaculty?.['ARTSC'] ??
+      null;
     this.fys = fys; // set this to be global here
     const aggEnrollments: number[] = [];
     const enrollmentCollection: number[][] = [];

--- a/src/app/cinterfaces.ts
+++ b/src/app/cinterfaces.ts
@@ -74,6 +74,8 @@ export interface ImportantTimestamps {
     isSummer?: boolean;
 }
 
+export type ImportantTimestampsByFaculty = Record<string, ImportantTimestamps>;
+
 export interface SessionsRaw{
     sessions: SessionInfo[];
     

--- a/src/app/crsgetter.service.ts
+++ b/src/app/crsgetter.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import {HttpClient} from '@angular/common/http';
-import { Course, ImportantTimestamps, SessionCollection, TopCourses } from './cinterfaces';
+import { Course, ImportantTimestampsByFaculty, SessionCollection, TopCourses } from './cinterfaces';
 import { DesCol } from './shared/autocompleteinterfaces';
 
 @Injectable({
@@ -50,9 +50,9 @@ export class CrsgetterService {
     return this.http.get<Course>(cPath);
   }
 
-  getImportantDates(): Observable<ImportantTimestamps> {
+  getImportantDates(): Observable<ImportantTimestampsByFaculty> {
     const tStampPath = this.crsPath + this.session + "/" + "constants" + this.suffix;
-    return this.http.get<ImportantTimestamps>(tStampPath);
+    return this.http.get<ImportantTimestampsByFaculty>(tStampPath);
   }
 
   getSessionCollection(): Observable<SessionCollection> {


### PR DESCRIPTION
This adds support for showing different dates (enrollment/drop/…) on the chart, based on who is offering the course. If dates are not known for a faculty code, the fallback is still FAS dates.

Previously, the dates were hardcoded to only appear when the campus code was `1`. I added `3` as well, to enable this for UTSC courses.

Data changes: https://github.com/ICPRplshelp/Enrollment-Data/pull/1